### PR TITLE
gitignore tests/setup/output/ — per-run setup-script artifacts (full inventory in body)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,11 @@ uv.lock
 # Generated fixture files in helper_programs (output artifacts)
 helper_programs/mk_gpucpunode_csv/*.json
 helper_programs/csv_to_fixtures/*.json
+
+# Per-run artifacts written by the setup-script pipeline
+# (tests/setup/setup_environment.sh, tests/setup/run_all.sh, tests/setup/user_smoke_test.sh,
+#  and every module under tests/setup/modules/). Contents include API tokens, generated
+#  random passwords, raw invoice JSON, and per-step .log files. CI publishes a redacted
+#  copy of this directory to the `smoke-test-artifacts` branch via tests/setup/lib/redact_secrets.sh;
+#  see tests/setup/output/ entry in the PR introducing this rule for the full inventory.
+tests/setup/output/

--- a/coldfront_orcd_direct_charge/VERSION_FOOTER.md
+++ b/coldfront_orcd_direct_charge/VERSION_FOOTER.md
@@ -1,3 +1,3 @@
-main
-ab706a6
-2026-04-21_13:37
+chore/gitignore-tests-setup-output
+feb2f23
+2026-04-21_13:56


### PR DESCRIPTION
## Summary

Adds `tests/setup/output/` to `.gitignore` so that per-run artifacts produced by the setup-script pipeline are never accidentally committed.

These artifacts:

- contain real secret material (API tokens, generated random passwords) on every run,
- change on every run (timestamps, generated tokens/passwords, fresh PKs),
- are machine-specific (absolute paths to the developer's clone appear inside several `.log` files),
- are already published by CI as both an unredacted private artifact (7 days) and a redacted persistent branch.

There is no value in version-controlling them, and there is real risk in doing so (Git Guardian / push protection / accidental fork exposure).

The single change is one entry in `.gitignore`:

```gitignore
# Per-run artifacts written by the setup-script pipeline
# (tests/setup/setup_environment.sh, tests/setup/run_all.sh, tests/setup/user_smoke_test.sh,
#  and every module under tests/setup/modules/). Contents include API tokens, generated
#  random passwords, raw invoice JSON, and per-step .log files. CI publishes a redacted
#  copy of this directory to the `smoke-test-artifacts` branch via tests/setup/lib/redact_secrets.sh;
#  see tests/setup/output/ entry in the PR introducing this rule for the full inventory.
tests/setup/output/
```

Verified locally with `git check-ignore -v` against three representative paths (a top-level `.log`, the API-tokens `.tsv`, and a nested invoice `.json`) — all three match the new rule on `.gitignore:16`.

---

## What lives under `tests/setup/output/` — full inventory

The directory layout mirrors the step numbering of `tests/setup/modules/NN_*.sh`. Every module writes its `*.log` (and any captured JSON/TSV) under a same-named subdirectory of `OUTPUT_DIR`, which is computed by `tests/setup/lib/common.sh` (defaults to `tests/setup/output/`). The four files at the top level come from the lighter-weight `user_smoke_test.sh` flow.

### Top-level files (from `user_smoke_test.sh`)

| File | Producer | What it contains | What you can manually check |
|---|---|---|---|
| `coldfront_server.log` | `tests/setup/user_smoke_test.sh` (Django `runserver` redirected to file) | Django `runserver` boot output: `Watching for file changes`, `System check identified no issues (0 silenced)`, version banner, `Starting development server at http://0.0.0.0:8000/`, plus inline access-log lines like `"GET / HTTP/1.1" 200 4831`. | "Did the dev server actually come up on the expected port?" — look for the `Starting development server at` line. "Did the smoke HTTP `GET /` succeed?" — look for `200` or `5xx` in the access lines. "Did Django reload mid-run?" — look for `… changed, reloading.` |
| `create_user.log` | `coldfront create_user` invoked from the smoke script | `Created user 'smokeuser' (email: …)`, `Generated new API token for 'smokeuser'`, the token itself (`API Token: <40-hex>`), and the random password (`Password (generated random): <16 printable chars>`). | "Was the smoke user created cleanly (no `User already exists` error)?" "Did the script generate a fresh token / password this run?" — both are sensitive; do not re-use across runs. |
| `user_search_pretty.json` | Smoke API call to `/user/search` (pretty-printed via `python -m json.tool`) | An array of one object: `{username, first_name, last_name, email, display}` for the smoke user. | "Did the API auth round-trip succeed?" — the search returns the user that `create_user.log` just minted. |
| `user_search_raw.json` | Same API call as above, raw HTTP body | Same payload, single line, no whitespace. | Diff against `user_search_pretty.json` to confirm the pretty-printer didn't reshape the data; useful when investigating JSON-encoding regressions. |

### `01_1_multiusers/` (from `tests/setup/modules/01_1_multiusers.sh`)

| File | What it contains | What you can manually check |
|---|---|---|
| `create_users.log` | One stanza per user: `Created user 'orcd_…' (email: …)`, `Generated new API token for '…'`, `API Token: <40-hex>`, optional `Added '…' to '<group>' group`, then `User creation complete.` | Count `^Created user ` lines and compare against the row count in your bulk-user config (e.g. `config/users_multi.yaml`). Spot-check that managers landed in the right groups (`Rate Manager`, `Billing Manager`, `Rental Manager`). |
| `all_users.json` | Full user list as returned by the admin API: `id`, `username`, `first_name`, `last_name`, `email`, `is_active`, `date_joined`, `last_modified`. | "Are all users `is_active=true`?" "Are the IDs contiguous starting from a known seed?" |
| `all_users_pretty.json` | Same as above, indented for diffing/review. | Same checks; this is the file to skim by eye. |
| `api_tokens.json` / `api_tokens_pretty.json` | Array of `{username, token}`. | Use as the input dictionary for any downstream `curl -H "Authorization: Token <…>"` smoke call. **Most-secret file in the directory.** |
| `api_tokens.tsv` | `username<TAB>token` — header row plus one row per user. | Same as above, optimised for shell pipelines (`awk -F\\t '$1=="orcd_u0"{print $2}'`). |

### Per-step subdirectories (from `tests/setup/modules/NN_*.sh`)

Each is a single `.log` capturing the `coldfront <subcommand>` output verbatim. The interesting "did it work?" data is the structured per-record summary that each `coldfront` command prints between blank lines.

| Subdir | File | What it contains | What you can manually check |
|---|---|---|---|
| `02_projects/` | `create_projects.log` | `Created project '…' with owner '…'` / `Updated existing project '…'`, then `Project setup complete.` with `Title`, `Owner`, `Status`. | Count `^Project setup complete\.$` and compare against the project count in `config/projects.yaml`. Confirm every project ends `Status: Active`. |
| `03_members/` | `add_members.log` | `Added role '<role>' for user '<u>' in project '<p>'`, optional `Created ColdFront ProjectUser record for '<u>'`, then `User added to project.` block with `User`, `Project`, `Role`, `All roles`. | Verify a known (user, project) pair has the expected roles. Confirm no `ProjectUser` insertions were skipped because the user wasn't created in step 01. |
| `04_1_attach_cost_allocations/` | `attach_cost_allocations.log` | Per-project: `Created new cost allocation for project '<p>'`, list of `Added cost object '<co>' at <pct>%`, then a `Cost allocation set successfully.` block (`Status: PENDING`/`APPROVED`, reviewer, list of cost objects, notes). | Confirm percentages on each project sum to 100. Spot-check the right reviewer (`orcd_bim`) is recorded. |
| `04_2_confirm_cost_allocations/` | `confirm_cost_allocations.log` | The reviewer-approval pass that flips `04_1` allocations from `PENDING` to `APPROVED`. | Count `Status: APPROVED` lines = number of projects that should be billable. |
| `04_cost_allocation/` | `set_cost_allocations.log` | Older single-step variant that does both attach + auto-approve in one go. Present only if a config still uses it. | Same as `04_1` + `04_2` combined. |
| `05_rates/` | `set_rates.log` | Per-SKU: `Created rate $<X> effective YYYY-MM-DD`, `SKU visibility …`, then `Rate set successfully.` with `SKU`, `Rate`, `Effective date`, `Billing unit` (`HOURLY`/`MONTHLY`), `Set by`, `Notes`, `Visibility`. | Confirm every SKU you expect (`NODE_H200x8`, etc.) has at least one rate row. Spot-check that effective dates are in the period you're about to invoice. |
| `06_1_create_reservations/` | `create_reservations.log` | First reservation wave. Per reservation: `Created reservation #N`, then `Reservation created successfully.` with `Reservation ID`, `Node`, `Project`, `Requesting User`, `Start`, `Duration`, `End`, `Status`. | Confirm `Status: Pending Approval` on every newly created reservation. Cross-check `End` against `Start + Duration`. |
| `06_add_amf/` | `add_amf.log` | Per user: `Updated maintenance status for '<u>'`, then `Account maintenance fee configured successfully.` with `User`, `Status` (`basic`/`advanced`), `Billing project`. | Confirm every user that should be on AMF appears once. |
| `07_1_create_reservations/` | `create_reservations.log` | Second reservation wave (typically the next billing month's set). Same shape as `06_1`. | Same checks as `06_1`. |
| `07_2_confirm_reservations/` | `confirm_reservations.log` | Per-reservation approval pass: `Reservation #N approved.`, then `Node`, `Project`, `Requesting user`, `Period`, `Duration`, `Processed by`, `Manager notes`. | Count `^Reservation #\d+ approved\.$` = reservations that should bill in this period. |
| `08_maintenance/` | `maintenance_windows.log` | Per window: `Created maintenance window #N: <title>` then `Start`, `End`, `Duration`. **Currently also captures Django `RuntimeWarning: DateTimeField …received a naive datetime` lines** from the underlying ORM call — those are real upstream warnings that should eventually be fixed. | Sanity-check: durations match `End - Start`. Note the count of naive-datetime `RuntimeWarning` lines for the issue tracker. |
| `09_invoices/` | `invoices.log` | Per month: `Fetching invoice for <Month> <YYYY> (<YYYY>-<MM>)…` then `HTTP 200 - saved to <abs path>/invoice_<YYYY>_<MM>.json`. | Confirm every expected month returns `HTTP 200`. Any `HTTP 4xx`/`5xx` here is a billing-API regression. |
| `09_invoices/` | `coldfront_server.log` | Same shape as the top-level `coldfront_server.log` but captured during the invoice run (the invoice module spins up its own `runserver`). | Same kind of checks as the top-level server log. |
| `09_invoices/` | `invoice_<YYYY>_<MM>.json` / `…_pretty.json` | The full invoice payload returned by the portal API: `metadata` (`year`, `month`, `month_name`, `generated_at`, `generated_by`, `invoice_status`, `total_reservations`, `excluded_count`, `total_amf_entries`, `total_qos_entries`), then `projects[]` with `project_id`, `project_title`, `project_owner`, `total_hours`, `cost_totals`, `reservations[]`, `amf_entries[]`. | "Does `metadata.total_reservations` match what `07_2` approved for this period?" "Are the AMF rows from `06_add_amf` showing up under each project's `amf_entries`?" "Do `cost_totals` sum to a sane dollar amount given step `05`'s rates × step `07_1/2`'s hours?" — this is the file to diff month-over-month when investigating an invoice anomaly. |

---

## Sensitive content these files contain

Two categories, both of which appear *every* run with fresh values:

1. **API tokens** — 40-character hex strings produced by Django REST Framework's `Token.objects.create(user=…)`. Present in:
   - `create_user.log` and `01_1_multiusers/create_users.log` (one per user, on `API Token: …` lines),
   - `01_1_multiusers/api_tokens.{json,tsv,_pretty.json}` (the structured exports),
   - any future module log that surfaces a token in plain text.

   These are real, working tokens against the local sqlite DB while it exists. They are disposable per run — but they grant full API access for the lifetime of the development DB, which can be hours or days on a developer machine.

2. **Generated random passwords** — 16-character printable-ASCII strings produced by `coldfront create_user --generate-password`. Currently visible in `create_user.log` ("`Password (generated random): …`"). Same caveats as tokens.

There is also non-secret-but-not-public content:

- Internal usernames like `cnh`, `milechin`, `secorey`, … (real account names of project members),
- Email addresses (`@example.edu` / `@example.com` for synthetic users; real `@…edu` addresses for the `01_1_multiusers` cohort that mirrors actual ORCD staff),
- Absolute file paths tied to a developer's home directory (`/Users/cnh/projects/orcd-rental-portal-002/...`) inside several `.log` files — harmless but personally identifying.

None of this needs to be in git history.

---

## How CI/CD handles this directory today (already in place, this PR does not change it)

`.github/workflows/user-management-tests.yml`, in this order, on every push:

1. **`actions/upload-artifact@v4`** — uploads `coldfront-orcd-direct-charge/tests/setup/output/` as the `user-smoke-output` artifact (7-day retention, accessible to repo collaborators). **This artifact is not redacted** — it intentionally preserves full fidelity for short-lived debugging. Treat the link the way you'd treat any short-lived staging credential dump.
2. **`tests/setup/lib/redact_secrets.sh tests/setup/output/`** — runs the in-tree masking pass:
   - JSON files: any key named `token` is rewritten to `"XXXX"` recursively.
   - TSV files: trailing 32-or-more-character hex column is rewritten to `XXXX`.
   - `*.log` / `*.txt` files: extensible regex array currently covers `API Token: <hex>` and `token<sep><hex>` patterns.
3. **`s0/git-publish-subdir-action@develop`** — pushes the now-redacted directory to the persistent `smoke-test-artifacts` branch with commit message `Artifacts for run {sha} - <run id>`. That branch is the long-term, public-safe history of what each smoke run produced.

So the practical answer to "where do I look at the artifacts after CI ran them?" is:

- **Need full token / password fidelity (debugging your own smoke run, within 7 days)?** → Open the failed/passed workflow run in Actions and download the `user-smoke-output` artifact zip.
- **Just want to compare an invoice or count reservations across runs?** → Browse the `smoke-test-artifacts` branch on GitHub. All API tokens there are `XXXX`.

---

## Why ignore-but-not-delete

This PR only adds the `.gitignore` rule. It does **not** `git rm -r tests/setup/output/`, because the directory was never tracked in the first place (it was always `??` in `git status`). The new rule means future contributors won't accidentally `git add tests/setup/output/` when staging unrelated files — a real risk, since the directory only appears after running the setup script and then sits in the working tree as an apparent untracked-file blob, easy to grab in a wildcard `git add .`.

If anyone in the future does want to commit a *single* curated artifact (e.g. a golden-master invoice JSON for a regression test), they can either move it out of `tests/setup/output/` to a non-ignored location (recommended), or use `git add -f path/to/file` after redacting it.

---

## What this PR is **not**

- Not a change to `redact_secrets.sh`. The masking script remains the single source of truth for the redaction rules; this PR just makes sure unredacted output never reaches `git add` in the first place.
- Not a change to the workflow ordering. The "upload unredacted, then redact, then push redacted" sequence is intentional (see "How CI/CD handles this directory today") and out of scope for a pure `.gitignore` change.
- Not a deletion of any file. Existing developer working trees that contain `tests/setup/output/` will simply stop seeing it in `git status`.
- Not a new directory. `tests/setup/output/` has existed and been populated by setup scripts since at least PR #65 / `tests/setup/run_all.sh`.

---

## Test plan

- [ ] After merging, fresh `git status` on a tree that has just been through `bash tests/setup/setup_environment.sh && bash tests/setup/run_all.sh` shows no `tests/setup/output/` entry under "Untracked files".
- [ ] `git check-ignore -v tests/setup/output/01_1_multiusers/api_tokens.tsv` prints `.gitignore:<line>:tests/setup/output/   tests/setup/output/01_1_multiusers/api_tokens.tsv` (verified locally on this branch).
- [ ] `.github/workflows/user-management-tests.yml` still produces the `user-smoke-output` artifact and still pushes to `smoke-test-artifacts`. (No workflow lines were touched.)
